### PR TITLE
Start Progman maximized when used as shell

### DIFF
--- a/pminit.c
+++ b/pminit.c
@@ -1788,7 +1788,7 @@ BOOL APIENTRY AppInit(HANDLE hInstance, LPTSTR lpszCmdLine, int nCmdShow)
 
 	bInNtSetup = FALSE;
 
-	if (lpszCmdLine && *lpszCmdLine && !lstrcmpi(lpszCmdLine, TEXT("/NTSETUP"))) {
+        if (lpszCmdLine && *lpszCmdLine && !lstrcmpi(lpszCmdLine, TEXT("/NTSETUP"))) {
 		//
 		// Progman was started from ntsetup.exe, so it can be exited
 		// without causing NT Windows to exit.
@@ -1839,11 +1839,26 @@ BOOL APIENTRY AppInit(HANDLE hInstance, LPTSTR lpszCmdLine, int nCmdShow)
 			//
 			bExitWindows = TRUE;
 		}
-	}
+        }
 
-	if (lpszCmdLine && *lpszCmdLine) {
-		nCmdShow = SW_SHOWMINNOACTIVE;
-	}
+        /*
+         * When Progman is launched as the system shell (bExitWindows is TRUE),
+         * the frame window should mimic the behaviour of the original Windows
+         * Program Manager and start maximised.  The original WinMain entry point
+         * received the nCmdShow parameter from the system which carried this
+         * information.  The 64-bit port uses wmain and initialised nCmdShow to
+         * SW_SHOWNORMAL, causing the shell to appear in a restored state when
+         * used as the replacement shell.  Explicitly set the show state to
+         * SW_SHOWMAXIMIZED when running as the default shell so that the window
+         * occupies the whole screen on logon.
+         */
+        if (bExitWindows) {
+                nCmdShow = SW_SHOWMAXIMIZED;
+        }
+
+        if (lpszCmdLine && *lpszCmdLine) {
+                nCmdShow = SW_SHOWMINNOACTIVE;
+        }
 
 
 	/*


### PR DESCRIPTION
## Summary
- ensure Progman opens fullscreen when configured as the system shell

## Testing
- `make test` *(fails: No rule to make target)*
- `x86_64-w64-mingw32-gcc -c -DUNICODE -D_UNICODE pminit.c` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b63b77af108329a48b677264a003b4